### PR TITLE
add date support, disabled for now

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,10 +1,5 @@
 {
-  "plugins": [
-    "transform-es2015-modules-commonjs",
-    "transform-es2015-destructuring",
-    "transform-es2015-parameters",
-    "transform-es2015-spread"
-  ],
+  "presets": ["es2015"],
 
   "ignore": "node_modules/"
 }

--- a/index.js
+++ b/index.js
@@ -1,10 +1,14 @@
 import compileExpression from 'filtrex'
 import replaceTags from './replaceTags'
+import replaceDates from './replaceDates'
+
 export default compile
 
 function compile(str) {
-  const functions = { includes }
-  return compileExpression(replaceTags(str), functions)
+  const functions = { includes, dateBetween }
+  str = replaceTags(str)
+  str = replaceDates(str)
+  return compileExpression(str, functions)
 }
 
 function includes (haystack, needle) {
@@ -14,5 +18,12 @@ function includes (haystack, needle) {
   }
 
   return false
+}
+
+function dateBetween (date, start, end) {
+  const afterStart = date >= new Date(start)
+  const beforeEnd = date <= new Date(end)
+
+  return (afterStart && beforeEnd)
 }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ export default compile
 function compile(str) {
   const functions = { includes, dateBetween }
   str = replaceTags(str)
-  str = replaceDates(str)
+  // TODO: turned off date replacement for the time being
+  // it conflicts with the way tick log -d works and defaults
+  //str = replaceDates(str)
   return compileExpression(str, functions)
 }
 

--- a/package.json
+++ b/package.json
@@ -15,12 +15,13 @@
   "license": "AGPL-3.0",
   "devDependencies": {
     "babel-cli": "^6.7.7",
-    "babel-plugin-transform-es2015-destructuring": "^6.6.5",
-    "babel-plugin-transform-es2015-modules-commonjs": "^6.7.7",
-    "babel-plugin-transform-es2015-parameters": "^6.7.0",
-    "babel-plugin-transform-es2015-spread": "^6.6.5",
-    "filtrex": "^0.5.4",
+    "babel-preset-es2015": "^6.6.0",
     "source-map-support": "^0.4.0",
     "tape": "^4.5.1"
+  },
+  "dependencies": {
+    "chrono-node": "^1.2.1",
+    "chrono-refiner-wholemonth": "0.0.4",
+    "filtrex": "^0.5.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tickbin-filter-parser",
   "version": "0.0.1",
   "description": "parse tickbin string filters into filter functions",
-  "main": "index.js",
+  "main": "build/index.js",
   "scripts": {
     "clean": "rm -rf build/*",
     "test": "tape -r source-map-support/register 'build/test/**/*.js'",

--- a/replaceDates.js
+++ b/replaceDates.js
@@ -1,0 +1,20 @@
+import chrono from 'chrono-node'
+import wholeMonth from 'chrono-refiner-wholemonth'
+
+export default replaceDates
+
+const parser = new chrono.Chrono
+parser.refiners.push(wholeMonth)
+
+function replaceDates(str) {
+  let result = str
+
+  for (let match of parser.parse(str)) {
+    let start = match.start.date().toISOString()
+    let end = match.end.date().toISOString()
+    let dateText = `dateBetween(date, "${start}", "${end}")`
+    result = result.replace(match.text, dateText)
+  }
+
+  return result
+}

--- a/replaceDates.js
+++ b/replaceDates.js
@@ -12,7 +12,7 @@ function replaceDates(str) {
   for (let match of parser.parse(str)) {
     let start = match.start.date().toISOString()
     let end = match.end.date().toISOString()
-    let dateText = `dateBetween(date, "${start}", "${end}")`
+    let dateText = `dateBetween(start, "${start}", "${end}")`
     result = result.replace(match.text, dateText)
   }
 

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -67,9 +67,9 @@ test('negating non-existing tags', t => {
   t.end()
 })
 
-const mar = { date: new Date('2016-03-15')}
-const apr = { date: new Date('2016-04-15')}
-const may = { date: new Date('2016-05-15')}
+const mar = { start: new Date('2016-03-15')}
+const apr = { start: new Date('2016-04-15')}
+const may = { start: new Date('2016-05-15')}
 
 test('filter on dates', t => {
   const exp = 'Mar - Apr 2016'  
@@ -77,6 +77,6 @@ test('filter on dates', t => {
 
   t.ok(filter(mar), 'March is in bounds')
   t.ok(filter(apr), 'April is in bounds')
-  t.notOk(filter(may), 'May is in bounds')
+  t.notOk(filter(may), 'May is out of bounds')
   t.end()
 })

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -66,3 +66,17 @@ test('negating non-existing tags', t => {
   t.notOk(filter(burrito), 'burrito is cheesy')
   t.end()
 })
+
+const mar = { date: new Date('2016-03-15')}
+const apr = { date: new Date('2016-04-15')}
+const may = { date: new Date('2016-05-15')}
+
+test('filter on dates', t => {
+  const exp = 'Mar - Apr 2016'  
+  const filter = compile(exp)
+
+  t.ok(filter(mar), 'March is in bounds')
+  t.ok(filter(apr), 'April is in bounds')
+  t.notOk(filter(may), 'May is in bounds')
+  t.end()
+})

--- a/test/compile.test.js
+++ b/test/compile.test.js
@@ -71,7 +71,8 @@ const mar = { start: new Date('2016-03-15')}
 const apr = { start: new Date('2016-04-15')}
 const may = { start: new Date('2016-05-15')}
 
-test('filter on dates', t => {
+// TODO: Skipping this test as we don't need date filtering integrated yet
+test.skip('filter on dates', t => {
   const exp = 'Mar - Apr 2016'  
   const filter = compile(exp)
 

--- a/test/replaceDates.test.js
+++ b/test/replaceDates.test.js
@@ -3,6 +3,6 @@ import replaceDates from '../replaceDates'
 
 test('replace single date', t => {
   const str = replaceDates('Feb - Mar')
-  t.equals(str, 'dateBetween(date, "2016-02-01T08:00:00.000Z", "2016-04-01T06:59:59.999Z")')
+  t.equals(str, 'dateBetween(start, "2016-02-01T08:00:00.000Z", "2016-04-01T06:59:59.999Z")')
   t.end()
 })

--- a/test/replaceDates.test.js
+++ b/test/replaceDates.test.js
@@ -1,0 +1,8 @@
+import test from 'tape'
+import replaceDates from '../replaceDates'
+
+test('replace single date', t => {
+  const str = replaceDates('Feb - Mar')
+  t.equals(str, 'dateBetween(date, "2016-02-01T08:00:00.000Z", "2016-04-01T06:59:59.999Z")')
+  t.end()
+})


### PR DESCRIPTION
This uses https://github.com/jonotron/chrono-refiner-wholemonth to create filter function for dates. I've disabled it for now though as it conflicts with the way `tickbin log -d` defaults