### PR TITLE
Parse with timezone offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "chrono-node": "^1.2.1",
-    "chrono-refiner-wholemonth": "0.0.4",
-    "moment": "^2.14.1"
+    "chrono-refiner-wholemonth": "0.0.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "chrono-node": "^1.2.1",
-    "chrono-refiner-wholemonth": "0.0.4"
+    "chrono-refiner-wholemonth": "0.0.4",
+    "moment": "^2.14.1"
   }
 }

--- a/src/extractDates.js
+++ b/src/extractDates.js
@@ -6,11 +6,18 @@ export default extractDates
 const parser = new chrono.Chrono
 parser.refiners.push(wholeMonth)
 
-function extractDates(str) {
+function extractDates(str, timezoneOffset) {
   let extracted = str
   const dates = [] 
 
   for (let match of parser.parse(str)) {
+    //  If timezoneOffset is supplied, this set's the parsed time into user's
+    //  timezone
+    if (timezoneOffset) {
+      match.start.assign('timezoneOffset', timezoneOffset)
+      match.end.assign('timezoneOffset', timezoneOffset)
+    }
+
     let startMoment = match.start.moment().startOf('day').utc()
     let endMoment = match.end.moment().endOf('day').utc()
     let start = startMoment.toDate()

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,8 @@ import extractDates from './extractDates'
 
 export default parse
 
-function parse(str) {
-  let {extracted, dates} = extractDates(str)
+function parse(str, timezoneOffset) {
+  let {extracted, dates} = extractDates(str, timezoneOffset)
   extracted = replaceTags(extracted)
 
   return {parsed: extracted, dates}

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -25,6 +25,7 @@ test('date relative to timezone offset', t => {
   //  Timezone of -24 hours (-1440 minites) to ensure different date
   const {dates} = parse('Feb - Mar 2016', -1440)
 
+  //  Feb 1 12am - Mar 31 11:59pm in UTC-1440 is the same as Feb 2 12am - April 1 11:59pm in UTC
   t.equals(dates[0].text, '(startArr >= [2016,1,2,0,0,0,0] and startArr <= [2016,3,1,23,59,59,999])')
   t.end()
 })

--- a/src/test/index.test.js
+++ b/src/test/index.test.js
@@ -20,3 +20,11 @@ test('replace single date', t => {
   t.equals(dates[0].text, '(startArr >= [2016,1,1,0,0,0,0] and startArr <= [2016,2,31,23,59,59,999])')
   t.end()
 })
+
+test('date relative to timezone offset', t => {
+  //  Timezone of -24 hours (-1440 minites) to ensure different date
+  const {dates} = parse('Feb - Mar 2016', -1440)
+
+  t.equals(dates[0].text, '(startArr >= [2016,1,2,0,0,0,0] and startArr <= [2016,3,1,23,59,59,999])')
+  t.end()
+})


### PR DESCRIPTION
This makes it so the parser works in the appropriate timezone. So if a user request a server to get the entries for Feb - Mar, they will get entries in that range from their timezone, not the timezone the server is running in.

@jonotron This okay to merge in?